### PR TITLE
feat: 게시글 좋아요 API 구현

### DIFF
--- a/src/main/java/com/sparta/springboards/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/springboards/config/WebSecurityConfig.java
@@ -51,8 +51,6 @@ public class WebSecurityConfig {
 
         //permitAll() 를 사용해서, 이런 URL 들을 인증하지 않고 실행 할 수 있게 함
         http.authorizeRequests().antMatchers("/api/auth/**").permitAll()
-//                .antMatchers("/api/search").permitAll()
-//                .antMatchers("/api/shop").permitAll()
                 //그 이외의 URL 요청들을 전부 다 authentication(인증 처리)하겠다
                 .anyRequest().authenticated()
                 // JWT 인증/인가를 사용하기 위한 설정
@@ -60,10 +58,6 @@ public class WebSecurityConfig {
                 //addFilterBefore: 어떤 Filter 이전에 추가하겠다 --> 우리가 만든 JwtAuthFilter 를 UsernamePasswordAuthenticationFilter 이전에 실행할 수 있도록
                 //1. JwtAuthFilter 를 통해 인증 객체를 만들고 --> 2. context 에 추가 --> 3.인증 완료 --> UsernamePasswordAuthenticationFilter 수행 --> 인증됐으므로 다음 Filter 로 이동 --> Controller 까지도 이동
                 .and().addFilterBefore(new JwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
-
-//        // Custom 로그인 페이지 사용
-//        // Security 에서 제공하는 default Form Login 을 사용하겠다
-//        http.formLogin().loginPage("/api/user/login-page").permitAll();
 
         //"거부"가 났을 때, 403 Forbidden 페이지(접근 제한 페이지) 이동 설정
         http.exceptionHandling().accessDeniedPage("/api/user/forbidden");

--- a/src/main/java/com/sparta/springboards/controller/BoardController.java
+++ b/src/main/java/com/sparta/springboards/controller/BoardController.java
@@ -29,7 +29,6 @@ public class BoardController {
     private final BoardService boardService;    //boardService 를 가져다 쓰겠다 (의존성 주입)
 
     //게시글 작성
-//    @Secured({"ROLE_ADMIN","ROLE_USER"})
     @PostMapping("/post")
     //BoardResponseDto 반환 타입, createBoard 메소드 명
     //@RequestBody: HTTP Method 안의 body 값을 Mapping(key:value 로 짝지어줌), BoardRequestDto: 넘어오는 데이터를 받아주는 객체
@@ -40,7 +39,6 @@ public class BoardController {
         return boardService.createBoard(requestDto, userDetails.getUser());
     }
 
-//    @Secured({"ROLE_ADMIN","ROLE_USER"})
     //전체 게시글 목록 조회
     @GetMapping("/posts")
     //BoardResponseDto 를 List 로 반환하는 타입, getListBoards 메소드 명, () 전부 Client 에게로 반환하므로 비워둠
@@ -49,7 +47,6 @@ public class BoardController {
         return boardService.getListBoards();
     }
 
-//    @Secured({"ROLE_ADMIN","ROLE_USER"})
     //선택한 게시글 조회
     @GetMapping("/post/{id}")
     //BoardResponseDto 반환 타입, getBoards 메소드 명
@@ -59,7 +56,6 @@ public class BoardController {
         return boardService.getBoard(id);
     }
 
-//    @Secured({"ROLE_ADMIN","ROLE_USER"})
     //선택한 게시글 수정(변경)
     @PutMapping("/post/{id}")
     //BoardResponseDto 반환 타입, updateBoard 메소드 명
@@ -72,7 +68,6 @@ public class BoardController {
         return boardService.updateBoard(id, requestDto, userDetails.getUser());
     }
 
-//    @Secured({"ROLE_ADMIN","ROLE_USER"})
     //선택한 게시글 삭제
     @DeleteMapping("/post/{id}")
     //MsgResponseDto 반환 타입, deleteBoard 메소드 명

--- a/src/main/java/com/sparta/springboards/controller/BoardController.java
+++ b/src/main/java/com/sparta/springboards/controller/BoardController.java
@@ -42,9 +42,9 @@ public class BoardController {
     //전체 게시글 목록 조회
     @GetMapping("/posts")
     //BoardResponseDto 를 List 로 반환하는 타입, getListBoards 메소드 명, () 전부 Client 에게로 반환하므로 비워둠
-    public List<BoardResponseDto> getListBoards() {
+    public List<BoardResponseDto> getListBoards(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         //() 모든 데이터를 담아서, boardService 로 응답을 보냄
-        return boardService.getListBoards();
+        return boardService.getListBoards(userDetails.getUser());
     }
 
     //선택한 게시글 조회

--- a/src/main/java/com/sparta/springboards/controller/BoardLikeController.java
+++ b/src/main/java/com/sparta/springboards/controller/BoardLikeController.java
@@ -1,0 +1,28 @@
+package com.sparta.springboards.controller;
+
+import com.sparta.springboards.dto.BoardResponseDto;
+import com.sparta.springboards.dto.MsgResponseDto;
+import com.sparta.springboards.security.UserDetailsImpl;
+import com.sparta.springboards.service.BoardLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/board/like")
+@RequiredArgsConstructor
+public class BoardLikeController {
+
+    private final BoardLikeService boardLikeService;
+
+    @PostMapping("/{boardId}")
+    public ResponseEntity<MsgResponseDto> saveBoardLike(
+            @PathVariable Long boardId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok().body(boardLikeService.saveBoradLike(boardId, userDetails.getUser()));
+    }
+}

--- a/src/main/java/com/sparta/springboards/controller/CommentController.java
+++ b/src/main/java/com/sparta/springboards/controller/CommentController.java
@@ -1,0 +1,40 @@
+package com.sparta.springboards.controller;
+
+import com.sparta.springboards.dto.CommentRequestDto;
+import com.sparta.springboards.dto.CommentResponseDto;
+import com.sparta.springboards.dto.MsgResponseDto;
+import com.sparta.springboards.security.UserDetailsImpl;
+import com.sparta.springboards.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/comment")
+@RequiredArgsConstructor
+
+public class CommentController {
+
+    private final CommentService commentService;
+
+    //댓글 작성
+    @PostMapping("/{id}")
+    public ResponseEntity<CommentResponseDto> createComment(@PathVariable Long id, @RequestBody CommentRequestDto commentRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok().body(commentService.createComment(id, commentRequestDto, userDetails.getUser()));
+    }
+
+    //댓글 수정(변경)
+    @PutMapping("/{boardId}/{cmtId}")
+    public ResponseEntity<CommentResponseDto> updateComment(@PathVariable Long boardId, @PathVariable Long cmtId, @RequestBody CommentRequestDto commentRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok().body(commentService.updateComment(boardId, cmtId, commentRequestDto, userDetails.getUser()));
+    }
+
+    //댓글 삭제
+    @DeleteMapping("/{boardId}/{cmtId}")
+    public ResponseEntity<MsgResponseDto> deleteComment(@PathVariable Long boardId, @PathVariable Long cmtId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        commentService.deleteComment(boardId, cmtId, userDetails.getUser());
+        return ResponseEntity.ok(new MsgResponseDto("삭제 성공", HttpStatus.OK.value()));
+    }
+}

--- a/src/main/java/com/sparta/springboards/dto/BoardResponseDto.java
+++ b/src/main/java/com/sparta/springboards/dto/BoardResponseDto.java
@@ -21,6 +21,8 @@ public class BoardResponseDto {
     private String title;
     private String contents;
     private String username;
+    private int likeCount;
+    private boolean likeCheck;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -38,11 +40,12 @@ public class BoardResponseDto {
 
     private List<CommentResponseDto> commentList = new ArrayList<>();
 
-    public BoardResponseDto(Board board, List<CommentResponseDto> commentList) {
+    public BoardResponseDto(Board board, List<CommentResponseDto> commentList, boolean boardLikeCheck) {
         this.id = board.getId();            //this.id: (위에서 선언된) 필드, Board 객체의 board 매개변수로 들어온 데이터를 getId() 에 담는다(Client 에게로 보내기 위해)
         this.title = board.getTitle();
         this.contents = board.getContents();
-        this.username = board.getUsername();
+        this.likeCount = board.getLikeCount();
+        this.likeCheck = boardLikeCheck;
         this.createdAt = board.getCreatedAt();
         this.modifiedAt = board.getModifiedAt();
         this.commentList = commentList;

--- a/src/main/java/com/sparta/springboards/dto/BoardResponseDto.java
+++ b/src/main/java/com/sparta/springboards/dto/BoardResponseDto.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 //@Getter, @Setter: 필드에 선언시 자동으로 get, set 메소드 생성. 클래스에서 선언시 모든 필드에 접근자와 설정자가 자동으로 생성
 @Getter
@@ -24,6 +26,7 @@ public class BoardResponseDto {
 
     //생성자
     public BoardResponseDto(Board board) {      //매개변수를 가지는 생성자
+
         this.id = board.getId();            //this.id: (위에서 선언된) 필드, Board 객체의 board 매개변수로 들어온 데이터를 getId() 에 담는다(Client 에게로 보내기 위해)
         this.title = board.getTitle();
         this.contents = board.getContents();
@@ -31,5 +34,17 @@ public class BoardResponseDto {
         this.createdAt = board.getCreatedAt();
         this.modifiedAt = board.getModifiedAt();
 
+    }
+
+    private List<CommentResponseDto> commentList = new ArrayList<>();
+
+    public BoardResponseDto(Board board, List<CommentResponseDto> commentList) {
+        this.id = board.getId();            //this.id: (위에서 선언된) 필드, Board 객체의 board 매개변수로 들어온 데이터를 getId() 에 담는다(Client 에게로 보내기 위해)
+        this.title = board.getTitle();
+        this.contents = board.getContents();
+        this.username = board.getUsername();
+        this.createdAt = board.getCreatedAt();
+        this.modifiedAt = board.getModifiedAt();
+        this.commentList = commentList;
     }
 }

--- a/src/main/java/com/sparta/springboards/dto/CommentRequestDto.java
+++ b/src/main/java/com/sparta/springboards/dto/CommentRequestDto.java
@@ -1,0 +1,12 @@
+package com.sparta.springboards.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+
+public class CommentRequestDto {
+    private String comment;
+
+}

--- a/src/main/java/com/sparta/springboards/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/springboards/dto/CommentResponseDto.java
@@ -1,0 +1,30 @@
+package com.sparta.springboards.dto;
+
+import com.sparta.springboards.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+
+
+//댓글 표시
+public class CommentResponseDto {
+    private Long id;
+    private String username;
+    private String comment;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public CommentResponseDto (Comment comment) {
+        this.id = comment.getId();
+        this.username = comment.getUsername();
+        this.comment = comment.getComment();;
+        this.createdAt = comment.getCreatedAt();
+        this.modifiedAt = comment.getModifiedAt();
+    }
+}

--- a/src/main/java/com/sparta/springboards/entity/Board.java
+++ b/src/main/java/com/sparta/springboards/entity/Board.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 //@Getter, @Setter: 필드에 선언시 자동으로 get, set 메소드 생성. 클래스에서 선언시 모든 필드에 접근자와 설정자가 자동으로 생성
 @Getter
@@ -24,8 +26,12 @@ public class Board extends Timestamped {
     //@GeneratedValue(strategy = GenerationType.IDENTITY) 또는 SEQUENCE) 또는 TABLE) 또는 AUTO)
     //각각의 기능: 기본 키 생성을 DB에 위임 (Mysql), DB 시퀀스를 사용해서 기본 키 할당 (ORACLE), 키 생성 테이블 사용 (모든 DB 사용 가능), 선택된 DB에 따라 자동으로 전략 선택
     //AUTO: DB에 따라 전략을 JPA 가 자동으로 선택되므로, DB를 변경해도 코드를 수정할 필요 없다는 장점
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
+    @OrderBy("createdAt DESC")
+    private List<Comment> comments = new ArrayList<>();
 
     //객체 필드를 테이블 컬럼과 매핑 + 여러 속성 설정 가능
     //nullable: null 허용 여부
@@ -39,7 +45,7 @@ public class Board extends Timestamped {
     private String contents;
 
     @ManyToOne
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
 

--- a/src/main/java/com/sparta/springboards/entity/Board.java
+++ b/src/main/java/com/sparta/springboards/entity/Board.java
@@ -44,6 +44,9 @@ public class Board extends Timestamped {
     @Column(nullable = false)
     private String contents;
 
+    @Column(nullable = false)
+    private int likeCount;
+
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -63,5 +66,9 @@ public class Board extends Timestamped {
         this.title = boardrequestDto.getTitle();             //this.title: (위에서 선언된) 필드, BoardRequestDto 객체의 requestDto 매개변수로 들어온 데이터를 getTitle() 에 담는다(DB 로 보내기 위해)
         this.contents = boardrequestDto.getContents();
 
+    }
+
+    public void updateLikeCount(int i) {
+        this.likeCount += i;
     }
 }

--- a/src/main/java/com/sparta/springboards/entity/BoardLike.java
+++ b/src/main/java/com/sparta/springboards/entity/BoardLike.java
@@ -1,0 +1,29 @@
+package com.sparta.springboards.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class BoardLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "BOARD_ID", nullable = false)
+    private Board board;
+
+    @ManyToOne
+    @JoinColumn(name = "USER_ID", nullable = false)
+    private User user;
+
+    public BoardLike(Board board, User user) {
+        this.board = board;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/sparta/springboards/entity/Comment.java
+++ b/src/main/java/com/sparta/springboards/entity/Comment.java
@@ -1,0 +1,42 @@
+package com.sparta.springboards.entity;
+
+import com.sparta.springboards.dto.CommentRequestDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Comment extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String comment;
+
+    public Comment(CommentRequestDto commentRequestDto, Board board, User user) {
+        this.comment = commentRequestDto.getComment();
+        this.username = user.getUsername();
+        this.board = board;
+        this.user = user;
+    }
+
+    public void update(CommentRequestDto commentRequestDto) {
+        this.comment = commentRequestDto.getComment();
+    }
+}

--- a/src/main/java/com/sparta/springboards/entity/User.java
+++ b/src/main/java/com/sparta/springboards/entity/User.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 //@Getter, @Setter: 필드에 선언시 자동으로 get, set 메소드 생성. 클래스에서 선언시 모든 필드에 접근자와 설정자가 자동으로 생성
 @Getter
@@ -26,8 +28,14 @@ public class User {
     //@GeneratedValue(strategy = GenerationType.IDENTITY) 또는 SEQUENCE) 또는 TABLE) 또는 AUTO)
     //각각의 기능: 기본 키 생성을 DB에 위임 (Mysql), DB 시퀀스를 사용해서 기본 키 할당 (ORACLE), 키 생성 테이블 사용 (모든 DB 사용 가능), 선택된 DB에 따라 자동으로 전략 선택
     //AUTO: DB에 따라 전략을 JPA 가 자동으로 선택되므로, DB를 변경해도 코드를 수정할 필요 없다는 장점
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @OneToMany(mappedBy = "user")
+    private List<Board> boardList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Comment> commentList = new ArrayList<>();
 
     //객체 필드를 테이블 컬럼과 매핑 + 여러 속성 설정 가능
     //nullable: null 허용 여부

--- a/src/main/java/com/sparta/springboards/repository/BoardLikeRepository.java
+++ b/src/main/java/com/sparta/springboards/repository/BoardLikeRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.springboards.repository;
+
+import com.sparta.springboards.entity.BoardLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
+    Optional<BoardLike> findByBoardIdAndUserId(Long boarId, Long userId);
+
+    void deleteByBoardIdAndUserId(Long boardId, Long id);
+}

--- a/src/main/java/com/sparta/springboards/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/springboards/repository/CommentRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.springboards.repository;
+
+import com.sparta.springboards.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Optional<Comment> findByIdAndUserId(Long cmtId, Long UserId);
+
+}

--- a/src/main/java/com/sparta/springboards/service/BoardLikeService.java
+++ b/src/main/java/com/sparta/springboards/service/BoardLikeService.java
@@ -1,0 +1,48 @@
+package com.sparta.springboards.service;
+
+import com.sparta.springboards.dto.MsgResponseDto;
+import com.sparta.springboards.entity.Board;
+import com.sparta.springboards.entity.BoardLike;
+import com.sparta.springboards.entity.User;
+import com.sparta.springboards.repository.BoardLikeRepository;
+import com.sparta.springboards.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class BoardLikeService {
+
+    private final BoardLikeRepository boardLikeRepository;
+    private final BoardRepository boardRepository;
+
+    @Transactional(readOnly = true)
+    public boolean checkBoradLike(Long boardId, User user) {
+        // 해당 회원의 좋아요 여부 확인
+        Optional<BoardLike> boardLike = boardLikeRepository.findByBoardIdAndUserId(boardId, user.getId());
+        return boardLike.isEmpty();
+    }
+
+    @Transactional
+    public MsgResponseDto saveBoradLike(Long boardId, User user) {
+        // 입력 받은 게시글 id와 일치하는 DB 조회
+        Board board = boardRepository.findById(boardId).orElseThrow(
+                () -> new NullPointerException("게시글이 존재하지 않습니다.")
+        );
+
+        // 해당 회원의 좋아요 여부를 확인하고 비어있으면 좋아요, 아니면 좋아요 취소
+        if (checkBoradLike(boardId, user)) {
+            boardLikeRepository.saveAndFlush(new BoardLike(board, user));
+            board.updateLikeCount(1);
+            return new MsgResponseDto("좋아요 완료", HttpStatus.OK.value());
+        } else {
+            boardLikeRepository.deleteByBoardIdAndUserId(boardId, user.getId());
+            board.updateLikeCount(-1);
+            return new MsgResponseDto("좋아요 취소", HttpStatus.OK.value());
+        }
+    }
+}

--- a/src/main/java/com/sparta/springboards/service/BoardService.java
+++ b/src/main/java/com/sparta/springboards/service/BoardService.java
@@ -2,12 +2,12 @@ package com.sparta.springboards.service;
 
 import com.sparta.springboards.dto.BoardRequestDto;
 import com.sparta.springboards.dto.BoardResponseDto;
+import com.sparta.springboards.dto.CommentResponseDto;
 import com.sparta.springboards.entity.Board;
+import com.sparta.springboards.entity.Comment;
 import com.sparta.springboards.entity.User;
 import com.sparta.springboards.entity.UserRoleEnum;
-import com.sparta.springboards.jwt.JwtUtil;
 import com.sparta.springboards.repository.BoardRepository;
-import com.sparta.springboards.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,8 +24,8 @@ public class BoardService {
 
     //의존성 주입
     private final BoardRepository boardRepository;
-    private final UserRepository userRepository;
-    private final JwtUtil jwtUtil;
+    //private final UserRepository userRepository;
+    //private final JwtUtil jwtUtil;
 
     //게시글 작성
     //클래스나 메서드에 붙여줄 경우, 해당 범위 내 메서드가 트랜잭션(데이터베이스 관리 시스템 또는 유사한 시스템에서 상호작용의 단위(더 이상 쪼개질 수 없는 최소의 연산))이 되도록 보장
@@ -55,8 +55,14 @@ public class BoardService {
 
         //반복문을 이용하여, boardList 에 담긴 데이터들을 객체 Board 로 모두 옮긴다
         for (Board board : boardList) {
+
+            List<CommentResponseDto> commentList = new ArrayList<>();
+            for (Comment comment : board.getComments()) {
+                commentList.add(new CommentResponseDto(comment));
+            }
+
             //board 를 새롭게 BoardResponseDto 로 옮겨담고, BoardResponseDto 를 boardResponseDto 안에 추가(add)한다
-            boardResponseDto.add(new BoardResponseDto(board));
+            boardResponseDto.add(new BoardResponseDto(board, commentList));
         }
         //최종적으로 옮겨담아진 boardResponseDto 를 반환
         return boardResponseDto;
@@ -79,7 +85,7 @@ public class BoardService {
     @Transactional
     //BoardResponseDto 반환 타입, updateBoard 메소드 명
     //Long id: 담을 데이터, BoardRequestDto: 넘어오는 데이터를 받아주는 객체, HttpServletRequest request 객체: 누가 로그인 했는지 알기위한 토큰을 담고 있음
-    public BoardResponseDto  updateBoard(Long id, BoardRequestDto requestDto, User user) {    //HttpServletRequest request?
+    public BoardResponseDto updateBoard(Long id, BoardRequestDto requestDto, User user) {    //HttpServletRequest request?
 
         Board board;    //board 를 사용하기위해서는 이런 변수 선언 필요함
 

--- a/src/main/java/com/sparta/springboards/service/CommentService.java
+++ b/src/main/java/com/sparta/springboards/service/CommentService.java
@@ -1,0 +1,87 @@
+package com.sparta.springboards.service;
+
+import com.sparta.springboards.dto.CommentRequestDto;
+import com.sparta.springboards.dto.CommentResponseDto;
+import com.sparta.springboards.entity.Board;
+import com.sparta.springboards.entity.Comment;
+import com.sparta.springboards.entity.User;
+import com.sparta.springboards.entity.UserRoleEnum;
+import com.sparta.springboards.repository.BoardRepository;
+import com.sparta.springboards.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public CommentResponseDto createComment(Long id, CommentRequestDto commentRequestDto, User user) {
+        Board board = boardRepository.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("게시글이 존재하지 않습니다.")
+        );
+
+        Comment comment = commentRepository.save(new Comment(commentRequestDto, board, user));
+        return new CommentResponseDto(comment);
+    }
+
+    @Transactional
+    public CommentResponseDto updateComment(Long boardId, Long cmtId, CommentRequestDto commentRequestDto, User user) {
+
+        // 게시글의 DB 저장 유무 확인
+        Board board = boardRepository.findById(boardId).orElseThrow (
+                () -> new IllegalArgumentException("게시글이 존재하지 않습니다.")
+        );
+
+        Comment comment;
+
+        if (user.getRole().equals(UserRoleEnum.ADMIN)) {
+            comment = commentRepository.findById(cmtId).orElseThrow(
+                    () -> new IllegalArgumentException("댓글이 존재하지 않습니다.")
+            );
+
+        } else {
+            //user 의 권한이 ADMIN 이 아니라면, 아이디가 같은 유저만 수정 가능
+            comment = commentRepository.findByIdAndUserId(cmtId, user.getId()).orElseThrow(
+                    () -> new IllegalArgumentException("댓글이 존재하지 않습니다.")
+            );
+        }
+
+        comment.update(commentRequestDto);
+
+        return new CommentResponseDto(comment);
+    }
+
+    @Transactional
+    public CommentResponseDto deleteComment(Long boardId, Long cmtId, User user) {
+
+        // 게시글의 DB 저장 유무 확인
+        Board board = boardRepository.findById(boardId).orElseThrow (
+                () -> new IllegalArgumentException("게시글이 존재하지 않습니다.")
+        );
+
+        Comment comment;
+
+        if (user.getRole().equals(UserRoleEnum.ADMIN)) {
+            comment = commentRepository.findById(cmtId).orElseThrow(
+                    () -> new IllegalArgumentException("댓글이 존재하지 않습니다.")
+            );
+
+        } else {
+            //user 의 권한이 ADMIN 이 아니라면, 아이디가 같은 유저만 수정 가능
+            comment = commentRepository.findByIdAndUserId(cmtId, user.getId()).orElseThrow(
+                    () -> new IllegalArgumentException("댓글이 존재하지 않습니다.")
+            );
+        }
+
+        // 해당 댓글 삭제
+        commentRepository.deleteById(cmtId);
+
+        return new CommentResponseDto(comment);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,3 @@ spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 jwt.secret.key=7ZWt7ZW0OTntmZTsnbTtjIXtlZzqta3snYTrhIjrqLjshLjqs4TroZzrgpjslYTqsIDsnpDtm4zrpa3tlZzqsJzrsJzsnpDrpbzrp4zrk6TslrTqsIDsnpA=
-
-logging.level.org.springframework=debug
-logging.level.org.springframework.web=debug


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feature/1-> develop

### 변경 사항
- 사용자가 이미 ‘좋아요’한 게시글에 다시 ‘좋아요’ 요청을 하면 ‘좋아요’ 했던 기록 취소
- 전체 조회, 상세 조회시 해당 회원의 ‘좋아요’ 여부 출력
- ‘좋아요’ 개수를 저장할 필드를 설정하여 상태값 저장

### 테스트 결과
현재 게시글 상세조회 부분은 수정 전입니다.
추후 수정 예정입니다.