### PR TITLE
feat: 게시글 상세 조회 시 회원의 좋아요 여부 반환

### DIFF
--- a/src/main/java/com/sparta/springboards/controller/BoardController.java
+++ b/src/main/java/com/sparta/springboards/controller/BoardController.java
@@ -51,9 +51,9 @@ public class BoardController {
     @GetMapping("/post/{id}")
     //BoardResponseDto 반환 타입, getBoards 메소드 명
     //@PathVariable: URL 경로에 변수를 넣기, Long id: 담을 데이터 --> 전체 게시글 목록에서 id 값으로 각각의 게시글을 구별
-    public BoardResponseDto getBoards(@PathVariable Long id) {
+    public BoardResponseDto getBoards(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         //id 값을 담아서, boardService 로 응답을 보냄
-        return boardService.getBoard(id);
+        return boardService.getBoard(id, userDetails.getUser());
     }
 
     //선택한 게시글 수정(변경)

--- a/src/main/java/com/sparta/springboards/service/BoardService.java
+++ b/src/main/java/com/sparta/springboards/service/BoardService.java
@@ -78,7 +78,7 @@ public class BoardService {
     //선택한 게시글 조회
     @Transactional(readOnly = true)
     //BoardResponseDto 반환 타입, getBoard 메소드 명, Long id: 담을 데이터
-    public BoardResponseDto getBoard(Long id) {
+    public BoardResponseDto getBoard(Long id, User user) {
         //Board: Entity 명, boardRepository 와 연결해서, id 를 찾는다
         Board board = boardRepository.findById(id).orElseThrow(
                 //매개변수가 의도치 않는 상황 유발시
@@ -91,7 +91,11 @@ public class BoardService {
         }
 
         //데이터가 들어간 객체 board 를 BoardResponseDto 로 반환
-        return new BoardResponseDto(board, commentList);
+        return new BoardResponseDto(
+                board,
+                commentList,
+                // 해당 회원의 해당 게시글 좋아요 여부
+                (checkBoardLike(board.getId(), user)));
     }
 
     //선택한 게시글 수정(변경)
@@ -124,7 +128,11 @@ public class BoardService {
         }
 
         //데이터가 들어간 객체 board 를 BoardResponseDto 로 반환
-        return new BoardResponseDto(board, commentList);
+        return new BoardResponseDto(
+                board,
+                commentList,
+                // 해당 회원의 해당 게시글 좋아요 여부
+                (checkBoardLike(board.getId(), user)));
 
     }
 


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feature/7 -> develop

### 변경 사항
- 게시글 상세 조회 시 회원의 좋아요 여부 함께 조회할 수 있도록

### 테스트 결과
CommentResponse 부분 에러 해결 후 테스트 바랍니다.