### PR TITLE
chore: 좋아요 기능 URI 통일

### DIFF
--- a/src/main/java/com/sparta/springboards/controller/BoardLikeController.java
+++ b/src/main/java/com/sparta/springboards/controller/BoardLikeController.java
@@ -13,13 +13,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/board/like")
+@RequestMapping("/api/like")
 @RequiredArgsConstructor
 public class BoardLikeController {
 
     private final BoardLikeService boardLikeService;
 
-    @PostMapping("/{boardId}")
+    @PostMapping("/board/{boardId}")
     public ResponseEntity<MsgResponseDto> saveBoardLike(
             @PathVariable Long boardId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/sparta/springboards/controller/CommentLikeController.java
+++ b/src/main/java/com/sparta/springboards/controller/CommentLikeController.java
@@ -14,11 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/user")
+@RequestMapping("/api/like")
 public class CommentLikeController {
     private final CommentLikeService commentLikeService;
 
-    @PostMapping("/commentlike/{commentId}")
+    @PostMapping("/comment/{commentId}")
     public MsgResponseDto commentLike(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long commentId) {
         return commentLikeService.CommentLike(userDetails.getUser(),commentId);
     }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feature/19-> 2week

### 변경 사항
- 현재 게시글 좋아요 URI : /api/board/like/{boardId} -> /api/like/board/{boardId]로 변경
- 현재 댓글 좋아요 URI : /api/user//commentlike/{commentId} -> /api/like/comment/{commentId}로 변경

### 테스트 결과
Postman 테스트 결과 이상 없습니다.