### PR TITLE
refactor: 게시글 좋아요 개수 반환 로직 변경

### DIFF
--- a/src/main/java/com/sparta/springboards/dto/BoardResponseDto.java
+++ b/src/main/java/com/sparta/springboards/dto/BoardResponseDto.java
@@ -21,8 +21,8 @@ public class BoardResponseDto {
     private String title;
     private String contents;
     private String username;
-    private int likeCount;
-    private boolean likeCheck;
+    private int boardLikeCount;
+    private boolean boardLikeCheck;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -44,8 +44,8 @@ public class BoardResponseDto {
         this.id = board.getId();            //this.id: (위에서 선언된) 필드, Board 객체의 board 매개변수로 들어온 데이터를 getId() 에 담는다(Client 에게로 보내기 위해)
         this.title = board.getTitle();
         this.contents = board.getContents();
-        this.likeCount = board.getLikeCount();
-        this.likeCheck = boardLikeCheck;
+        this.boardLikeCount = board.getBoardLikeList().size();
+        this.boardLikeCheck = boardLikeCheck;
         this.createdAt = board.getCreatedAt();
         this.modifiedAt = board.getModifiedAt();
         this.commentList = commentList;

--- a/src/main/java/com/sparta/springboards/entity/Board.java
+++ b/src/main/java/com/sparta/springboards/entity/Board.java
@@ -34,6 +34,9 @@ public class Board extends Timestamped {
     @OrderBy("createdAt DESC")
     private List<Comment> comments = new ArrayList<>();
 
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
+    private List<BoardLike> boardLikeList = new ArrayList<>();
+
     //객체 필드를 테이블 컬럼과 매핑 + 여러 속성 설정 가능
     //nullable: null 허용 여부
     @Column(nullable = false)
@@ -44,9 +47,6 @@ public class Board extends Timestamped {
 
     @Column(nullable = false)
     private String contents;
-
-    @Column(nullable = false)
-    private int likeCount;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
@@ -66,9 +66,5 @@ public class Board extends Timestamped {
     public void update(BoardRequestDto boardrequestDto) {       //boardrequestDto? requestDto?
         this.title = boardrequestDto.getTitle();             //this.title: (위에서 선언된) 필드, BoardRequestDto 객체의 requestDto 매개변수로 들어온 데이터를 getTitle() 에 담는다(DB 로 보내기 위해)
         this.contents = boardrequestDto.getContents();
-    }
-
-    public void updateLikeCount(int i) {
-        this.likeCount += i;
     }
 }

--- a/src/main/java/com/sparta/springboards/repository/BoardLikeRepository.java
+++ b/src/main/java/com/sparta/springboards/repository/BoardLikeRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
     Optional<BoardLike> findByBoardIdAndUserId(Long boarId, Long userId);
 
-    void deleteByBoardIdAndUserId(Long boardId, Long id);
+    void deleteByBoardIdAndUserId(Long boardId, Long userId);
 }

--- a/src/main/java/com/sparta/springboards/service/BoardService.java
+++ b/src/main/java/com/sparta/springboards/service/BoardService.java
@@ -173,7 +173,7 @@ public class BoardService {
     public boolean checkBoardLike(Long boardId, User user) {
         // 해당 회원의 좋아요 여부 확인
         Optional<BoardLike> boardLike = boardLikeRepository.findByBoardIdAndUserId(boardId, user.getId());
-        return boardLike.isEmpty();
+        return boardLike.isPresent();
     }
 
     @Transactional
@@ -184,13 +184,11 @@ public class BoardService {
         );
 
         // 해당 회원의 좋아요 여부를 확인하고 비어있으면 좋아요, 아니면 좋아요 취소
-        if (checkBoardLike(boardId, user)) {
+        if (!checkBoardLike(boardId, user)) {
             boardLikeRepository.saveAndFlush(new BoardLike(board, user));
-            board.updateLikeCount(1);
             return new MsgResponseDto("좋아요 완료", HttpStatus.OK.value());
         } else {
             boardLikeRepository.deleteByBoardIdAndUserId(boardId, user.getId());
-            board.updateLikeCount(-1);
             return new MsgResponseDto("좋아요 취소", HttpStatus.OK.value());
         }
     }


### PR DESCRIPTION

### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feature/17-> develop

### 변경 사항
- 좋아요 개수를 저장하는 상태 필드를 설정하여 좋아요 개수 출력 -> 다대일 양방향 매핑으로 DTO내에서 list().size()로 출력

### 테스트 결과
Postman 테스트 결과 이상 없습니다.