### PR TITLE
chore : Service부분 CustomException 내용 변경

### DIFF
--- a/src/main/java/com/sparta/springboards/service/BoardService.java
+++ b/src/main/java/com/sparta/springboards/service/BoardService.java
@@ -139,7 +139,7 @@ public class BoardService {
         } else {
             //user 의 권한이 ADMIN 이 아니라면, 아이디가 같은 유저만 수정 가능
             board = boardRepository.findByIdAndUserId(id, user.getId()).orElseThrow(
-                    () -> new CustomException(NOT_FOUND_USER)
+                    () -> new CustomException(AUTHORIZATION)
             );
         }
 
@@ -182,7 +182,7 @@ public class BoardService {
         } else {
             //user 의 권한이 ADMIN 이 아니라면, 아이디가 같은 유저만 수정 가능
             board = boardRepository.findByIdAndUserId(id, user.getId()).orElseThrow(
-                    () -> new CustomException(NOT_FOUND_USER)
+                    () -> new CustomException(AUTHORIZATION)
             );
         }
 

--- a/src/main/java/com/sparta/springboards/service/CommentService.java
+++ b/src/main/java/com/sparta/springboards/service/CommentService.java
@@ -57,7 +57,7 @@ public class CommentService {
         } else {
             //user 의 권한이 ADMIN 이 아니라면, 아이디가 같은 유저만 수정 가능
             comment = commentRepository.findByIdAndUserId(cmtId, user.getId()).orElseThrow(
-                    () -> new CustomException(NOT_FOUND_COMMENT)
+                    () -> new CustomException(AUTHORIZATION)
             );
         }
 
@@ -80,7 +80,7 @@ public class CommentService {
         } else {
             //user 의 권한이 ADMIN 이 아니라면, 아이디가 같은 유저만 수정 가능
             comment = commentRepository.findByIdAndUserId(cmtId, user.getId()).orElseThrow(
-                    () -> new CustomException(NOT_FOUND_COMMENT)
+                    () -> new CustomException(AUTHORIZATION)
             );
         }
         //해당 댓글 삭제


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feature/28-> develop

### 변경 사항
Service의 updateComment, deleteComment에서 아이디가 일치하지 않을 경우에
CustomException의 NOT_FOUND_COMMENT, NOT_FOUND_USER를 AUTHORIZATION으로 변경

### 테스트 결과
Postman 테스트 결과 이상 없습니다.