### PR TITLE
대댓글 기능 추가 

### DIFF
--- a/src/main/java/com/sparta/springboards/controller/BoardController.java
+++ b/src/main/java/com/sparta/springboards/controller/BoardController.java
@@ -43,9 +43,14 @@ public class BoardController {
     //전체 게시글 목록 조회
     @GetMapping("/boards")
     //BoardResponseDto 를 List 로 반환하는 타입, getListBoards 메소드 명, () 전부 Client 에게로 반환하므로 비워둠
-    public List<BoardResponseDto> getListBoards(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam String category) {
+    public List<BoardResponseDto> getListBoards(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         //() 모든 데이터를 담아서, boardService 로 응답을 보냄
-        return boardService.getListBoards(userDetails.getUser(),category);
+        return boardService.getListBoards(userDetails.getUser());
+    }
+
+    @GetMapping("/boards/{category}")
+    public List<BoardResponseDto> getCategoryListBoards(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable String category){
+        return boardService.getCategoryListBoards(userDetails.getUser(),category);
     }
 
 

--- a/src/main/java/com/sparta/springboards/controller/CommentController.java
+++ b/src/main/java/com/sparta/springboards/controller/CommentController.java
@@ -20,9 +20,9 @@ public class CommentController {
     private final CommentService commentService;
 
     //댓글 작성
-    @PostMapping("/{id}")
-    public ResponseEntity<CommentResponseDto> createComment(@PathVariable Long id, @RequestBody CommentRequestDto commentRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return ResponseEntity.ok().body(commentService.createComment(id, commentRequestDto, userDetails.getUser()));
+    @PostMapping("/{boardId}/{commentId}")
+    public ResponseEntity<CommentResponseDto> createComment(@PathVariable Long boardId,@PathVariable Long commentId,@RequestBody CommentRequestDto commentRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok().body(commentService.createComment(boardId,commentId, commentRequestDto, userDetails.getUser()));
     }
 
     //댓글 수정(변경)

--- a/src/main/java/com/sparta/springboards/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/springboards/dto/CommentResponseDto.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -18,15 +20,32 @@ public class CommentResponseDto {
     private String username;
     private String comment;
     private int CommentLike;
+
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public CommentResponseDto (Comment comment, int cnt) {
+    private List<CommentResponseDto
+            > childComment = new ArrayList<>();
+
+    public CommentResponseDto(Comment comment, int cnt) {
         this.id = comment.getId();
         this.username = comment.getUsername();
         this.comment = comment.getComment();
         this.CommentLike = cnt;
         this.createdAt = comment.getCreatedAt();
         this.modifiedAt = comment.getModifiedAt();
+
     }
+
+    public CommentResponseDto(Comment comment, int cnt, List<CommentResponseDto> childcomment) {
+        this.id = comment.getId();
+        this.username = comment.getUsername();
+        this.comment = comment.getComment();
+        this.CommentLike = cnt;
+        this.createdAt = comment.getCreatedAt();
+        this.modifiedAt = comment.getModifiedAt();
+        this.childComment = childcomment;
+    }
+
+
 }

--- a/src/main/java/com/sparta/springboards/entity/Category.java
+++ b/src/main/java/com/sparta/springboards/entity/Category.java
@@ -1,0 +1,23 @@
+package com.sparta.springboards.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum Category {
+    Spring("Spring"),
+    Java("Java"),
+    TIL("TIL");
+
+
+    private final String category;
+
+    public static Category valueOfCategory(String category){
+        return Arrays.stream(values())
+                .filter(value -> value.category.equals(category))
+                .findAny()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/sparta/springboards/entity/Comment.java
+++ b/src/main/java/com/sparta/springboards/entity/Comment.java
@@ -1,10 +1,13 @@
 package com.sparta.springboards.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sparta.springboards.dto.CommentRequestDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -29,7 +32,13 @@ public class Comment extends Timestamped {
     @Column(nullable = false)
     private String comment;
 
+    @JsonIgnore
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
 
+    @OneToMany(mappedBy = "parent")
+    private List<Comment> children = new ArrayList<>();
 
 
 
@@ -39,6 +48,14 @@ public class Comment extends Timestamped {
         this.board = board;
         this.user = user;
     }
+    public Comment(CommentRequestDto commentRequestDto,Board board, User user, Comment comment){
+        this.comment = commentRequestDto.getComment();
+        this.username = user.getUsername();
+        this.board = board;
+        this.user = user;
+        this.parent = comment;
+    }
+
 
     public void update(CommentRequestDto commentRequestDto) {
         this.comment = commentRequestDto.getComment();

--- a/src/main/java/com/sparta/springboards/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/springboards/repository/CommentRepository.java
@@ -10,4 +10,7 @@ import java.util.Optional;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Optional<Comment> findByIdAndUserId(Long cmtId, Long UserId);
 
+    Optional<Comment> findAllByIdAndBoardId(Long parentId, Long BoardId);
+
+
 }

--- a/src/main/java/com/sparta/springboards/service/BoardService.java
+++ b/src/main/java/com/sparta/springboards/service/BoardService.java
@@ -6,6 +6,7 @@ import com.sparta.springboards.exception.CustomException;
 import com.sparta.springboards.repository.BoardLikeRepository;
 import com.sparta.springboards.repository.BoardRepository;
 import com.sparta.springboards.repository.CommentLikeRepository;
+import com.sparta.springboards.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,7 @@ public class BoardService {
     private final BoardRepository boardRepository;
     private final BoardLikeRepository boardLikeRepository;
     private final CommentLikeRepository commentLikeRepository;
+    private final CommentRepository commentRepository;
     //private final UserRepository userRepository;
     //private final JwtUtil jwtUtil;
 
@@ -110,10 +112,19 @@ public class BoardService {
         );
 
         List<CommentResponseDto> commentList = new ArrayList<>();
-        for (Comment comment : board.getComments()) {
-            commentList.add(new CommentResponseDto(comment,commentLikeRepository.countAllByCommentId(comment.getId())));
-        }
+        List<CommentResponseDto> childCommentList = new ArrayList<>();
 
+        for (Comment comment : board.getComments()) {
+            if(comment.getParent()==null) {
+                for(Comment comment1 : comment.getChildren()){
+                  if(id == comment1.getBoard().getId()) {
+                      childCommentList.add(new CommentResponseDto(comment1, commentLikeRepository.countAllByCommentId(comment1.getBoard().getId())));
+                  }
+                }
+                commentList.add(new CommentResponseDto(comment, commentLikeRepository.countAllByCommentId(comment.getId()),childCommentList));
+            }
+            childCommentList = new ArrayList<>();
+        }
         //데이터가 들어간 객체 board 를 BoardResponseDto 로 반환
         return new BoardResponseDto(
                 board,

--- a/src/main/java/com/sparta/springboards/service/CommentService.java
+++ b/src/main/java/com/sparta/springboards/service/CommentService.java
@@ -29,12 +29,22 @@ public class CommentService {
     private final CommentLikeRepository commentLikeRepository;
 
     @Transactional
-    public CommentResponseDto createComment(Long id, CommentRequestDto commentRequestDto, User user) {
+    public CommentResponseDto createComment(Long id, Long commentId, CommentRequestDto commentRequestDto, User user) {
         Board board = boardRepository.findById(id).orElseThrow(
                 () -> new CustomException(NOT_FOUND_BOARD)
         );
-
-        Comment comment = commentRepository.save(new Comment(commentRequestDto, board, user));
+        Comment comment;
+        if(commentId == 0){
+            comment = commentRepository.save(new Comment(commentRequestDto, board, user));
+        }else{
+            Comment childComment = commentRepository.findById(commentId).orElseThrow(
+                    () -> new CustomException(NOT_FOUND_COMMENT)
+            );
+            if(commentRepository.findAllByIdAndBoardId(commentId,board.getId()).isEmpty()){
+                throw new CustomException(NOT_FOUND_COMMENT);
+            }
+            comment = commentRepository.save(new Comment(commentRequestDto, board, user, childComment));
+        }
         int cnt = 0;
         return new CommentResponseDto(comment,cnt);
     }

--- a/src/main/java/com/sparta/springboards/service/CommentService.java
+++ b/src/main/java/com/sparta/springboards/service/CommentService.java
@@ -45,8 +45,7 @@ public class CommentService {
             }
             comment = commentRepository.save(new Comment(commentRequestDto, board, user, childComment));
         }
-        int cnt = 0;
-        return new CommentResponseDto(comment,cnt);
+        return new CommentResponseDto(comment,0);
     }
 
     @Transactional


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feature/30-> develop

### 변경 사항
- 대댓글 기능 추가. 
 -> Comment에서 부모 댓글과, 자식 댓글 연관관계를 맺어서 진행
 -> Comment 작성시 /게시글id/댓글id 를 적는 방식으로 변경후, 댓글 id== 0이면 부모 댓글, 0이 아닌 경우는 자식 댓글
      ex) localhost:8080/api/comment/2/0 => 2번 게시글의 부모댓글 작성
      ex) localhost:8080/api/comment/2/2 => 2번 게시글의 댓글id가 2번인 댓글에 대댓글 작성

### 테스트 결과
Postman 테스트 결과 이상 없습니다.